### PR TITLE
Add http error retry, add delay for dev env

### DIFF
--- a/client-v2/src/app/http/http.service.ts
+++ b/client-v2/src/app/http/http.service.ts
@@ -1,11 +1,73 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { Store } from '@ngrx/store'
-import { OperatorFunction, catchError, Observable, throwError, mergeMap } from 'rxjs'
+import { OperatorFunction, catchError, Observable, throwError, mergeMap, delay, tap, retry, timer } from 'rxjs'
 import { environment } from 'src/environments/environment'
 import { AppState } from '../store'
 import { userSelectors } from '../store/user/user.selectors'
 import { HttpClientOptions } from './types'
+
+const useDelay = <T>(enable = environment.CONTEXT == 'Development') => {
+    if (!enable) return tap<T>()
+    return delay<T>(500)
+}
+
+/** catches errors and re-throws an `HttpServerErrorResponse` */
+const interceptErrors = <T>(http: HttpService): OperatorFunction<T, T> => {
+    return <T>(source: Observable<T>) => {
+        return source.pipe(
+            retry({
+                count: 4,
+                delay: (err: HttpErrorResponse) => {
+                    if (!navigator.onLine) throwError(() => err)
+                    return timer(300)
+                },
+            }),
+            catchError<T, Observable<T>>(({ type, ...err }: HttpErrorResponse) => {
+                if (err.status !== 0) return throwError(() => err)
+
+                // check if client is connected to internet
+                if (!navigator.onLine)
+                    return throwError(() => ({
+                        ...err,
+                        error: {
+                            statusCode: '0 - OFFLINE',
+                            message: 'You are offline. Please connect to the internet and try again.',
+                            error: 'network error',
+                        },
+                    }))
+
+                // check if the server is even up
+                return http.get('/health', { disableErrorInterception: true }).pipe(
+                    // server is up
+                    mergeMap(() => {
+                        return throwError(() => ({
+                            ...err,
+                            error: {
+                                statusCode: 0,
+                                message:
+                                    'An unknown error occurred. Please refresh and try again. If the problem presists, please report it.',
+                                error: 'unknown',
+                            },
+                        }))
+                    }),
+                    // server is down
+                    catchError<T, Observable<T>>(err => {
+                        console.warn('second catchError catched:', err)
+                        return throwError(() => ({
+                            ...err,
+                            error: {
+                                statusCode: '0 - SERVER DOWN',
+                                message: 'We may be experiencing some issues with the server. Please report it.',
+                                error: 'server error',
+                            },
+                        }))
+                    })
+                )
+            })
+        )
+    }
+}
 
 @Injectable({
     providedIn: 'root',
@@ -18,13 +80,6 @@ export class HttpService {
     private bearerToken?: string | null
     private baseUrl = environment.SERVER_BASE_URL
 
-    // /**
-    //  * @param endpoint Note: needs to start with a slash
-    //  * @param options The HTTP options to send with the request. */
-    // getAsync<T>(...args: Parameters<HttpService['get']>) {
-    //     const res = this.get<T>(...args)
-    //     return promisifyObservable(res, 'if error property exists')
-    // }
     /**
      * @param endpoint Note: needs to start with a slash
      * @param options The HTTP options to send with the request. */
@@ -32,18 +87,9 @@ export class HttpService {
         const url = this.baseUrl + endpoint
         const response$ = this.http.get<T>(url, this.addBearerToken(options))
 
-        if (options?.disableErrorInterception) return response$
-        return response$.pipe(this.getErrorInterceptor())
+        return this.handleResponse(response$, options)
     }
 
-    // /**
-    //  * @param endpoint Note: needs to start with a slash
-    //  * @param body
-    //  * @param options The HTTP options to send with the request. */
-    // postAsync<T>(...args: Parameters<HttpService['post']>) {
-    //     const res = this.post<T>(...args)
-    //     return promisifyObservable(res, 'if error property exists')
-    // }
     /**
      * @param endpoint Note: needs to start with a slash
      * @param body
@@ -53,8 +99,7 @@ export class HttpService {
         const url = this.baseUrl + endpoint
         const response$ = this.http.post<T>(url, body || {}, this.addBearerToken(options))
 
-        if (options?.disableErrorInterception) return response$
-        return response$.pipe(this.getErrorInterceptor())
+        return this.handleResponse(response$, options)
     }
 
     /**
@@ -66,75 +111,31 @@ export class HttpService {
         const url = this.baseUrl + endpoint
         const response$ = this.http.patch<T>(url, body, this.addBearerToken(options))
 
-        if (options?.disableErrorInterception) return response$
-        return response$.pipe(this.getErrorInterceptor())
+        return this.handleResponse(response$, options)
     }
 
     delete<T>(endpoint: string, options?: HttpClientOptions<'delete'>) {
         const url = this.baseUrl + endpoint
         const response$ = this.http.delete<T>(url, this.addBearerToken(options))
 
-        if (options?.disableErrorInterception) return response$
-        return response$.pipe(this.getErrorInterceptor())
+        return this.handleResponse(response$, options)
+    }
+
+    private handleResponse<T>(response$: Observable<T>, options: HttpClientOptions | undefined) {
+        if (options?.disableErrorInterception) return response$.pipe(useDelay())
+
+        return response$.pipe(useDelay(), interceptErrors(this))
     }
 
     /** adds bearer token inside the 'headers'*/
-    private addBearerToken<T extends HttpClientOptions>(options: T | undefined): HttpClientOptions {
+    private addBearerToken(options: HttpClientOptions | undefined): HttpClientOptions {
         if (!this.bearerToken) return options || {}
 
-        return {
-            ...(options || {}),
-            headers: {
-                ...(options?.headers || {}),
-                Authorization: `Bearer ${this.bearerToken}`,
-            },
-        }
-    }
+        options ||= {}
+        options.headers ||= {}
+        const headers = options.headers as { Authorization: string }
+        headers.Authorization ||= `Bearer ${this.bearerToken}`
 
-    /** catches errors and re-throws an `HttpServerErrorResponse` */
-    private getErrorInterceptor<T>(): OperatorFunction<T, T> {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        return catchError<T, Observable<T>>(({ type, ...err }: HttpErrorResponse) => {
-            if (err.status !== 0) return throwError(() => err)
-
-            // check if client is connected to internet
-            if (!navigator.onLine)
-                return throwError(() => ({
-                    ...err,
-                    error: {
-                        statusCode: '0 - OFFLINE',
-                        message: 'You are offline. Please connect to the internet and try again.',
-                        error: 'network error',
-                    },
-                }))
-
-            // check if the server is even up
-            return this.get('/health', { disableErrorInterception: true }).pipe(
-                // server is up
-                mergeMap(() => {
-                    return throwError(() => ({
-                        ...err,
-                        error: {
-                            statusCode: 0,
-                            message:
-                                'An unknown error occurred. Please refresh and try again. If the problem presists, please report it.',
-                            error: 'unknown',
-                        },
-                    }))
-                }),
-                // server is down
-                catchError<T, Observable<T>>(err => {
-                    console.warn('second catchError catched:', err)
-                    return throwError(() => ({
-                        ...err,
-                        error: {
-                            statusCode: '0 - SERVER DOWN',
-                            message: 'We may be experiencing some issues with the server. Please report it.',
-                            error: 'server error',
-                        },
-                    }))
-                })
-            )
-        })
+        return options
     }
 }


### PR DESCRIPTION
# Changes/Additions
- Add retry to http errors (up to 4 times)
- Add small delay on dev env to simulate network latency
- Pull out error interceptor into an operator, separate from `HttpService`