### PR TITLE
feat: order entities by `createdAt`

### DIFF
--- a/apps/rockket-backend/src/entities/list/list.repository.ts
+++ b/apps/rockket-backend/src/entities/list/list.repository.ts
@@ -114,7 +114,9 @@ export class ListRepository {
                 id: true,
                 title: true,
                 childLists: { select: { id: true } },
+                createdAt: true,
             },
+            orderBy: { createdAt: 'desc' },
         })
 
         return lists.map(({ childLists, ...list }) => ({
@@ -132,7 +134,9 @@ export class ListRepository {
                 id: true,
                 parentListId: true,
                 title: true,
+                createdAt: true,
             },
+            orderBy: { createdAt: 'desc' },
         })
 
         return lists
@@ -141,6 +145,7 @@ export class ListRepository {
     async getChildTasklists(listId: string) {
         return await this.prisma.tasklist.findMany({
             where: { parentListId: listId },
+            orderBy: { createdAt: 'desc' },
         })
     }
 

--- a/apps/rockket-web/src/app/pages/component-playground/tasks-demo/tasks-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/component-playground/tasks-demo/tasks-demo.component.ts
@@ -30,6 +30,8 @@ const tasklist = Object.values(TaskStatus)
             id: '',
             listId: '',
             parentTaskId: '',
+            closedAt: null,
+            createdAt: new Date().toISOString(),
         })),
     )
     .flat()

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-description-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-description-demo.component.ts
@@ -29,6 +29,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
 ]
 

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-nesting-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-nesting-demo.component.ts
@@ -11,6 +11,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         status: TaskStatus.OPEN,
         priority: TaskPriority.NONE,
         parentTaskId: '',
+        closedAt: null,
+        createdAt: new Date().toISOString(),
         children: [
             {
                 id: listId + 'task-one-zero',
@@ -21,6 +23,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 priority: TaskPriority.NONE,
                 parentTaskId: '',
                 children: [],
+                createdAt: new Date().toISOString(),
+                closedAt: null,
             },
             {
                 id: listId + 'task-one-one',
@@ -30,6 +34,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 status: TaskStatus.OPEN,
                 priority: TaskPriority.NONE,
                 parentTaskId: '',
+                closedAt: null,
+                createdAt: new Date().toISOString(),
                 children: [
                     {
                         id: listId + 'task-one-one-one',
@@ -40,6 +46,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                         priority: TaskPriority.NONE,
                         parentTaskId: '',
                         children: [],
+                        createdAt: new Date().toISOString(),
+                        closedAt: null,
                     },
                     {
                         id: listId + 'task-one-one-two',
@@ -50,6 +58,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                         priority: TaskPriority.NONE,
                         parentTaskId: '',
                         children: [],
+                        createdAt: new Date().toISOString(),
+                        closedAt: null,
                     },
                 ],
             },
@@ -70,6 +80,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 priority: TaskPriority.NONE,
                 parentTaskId: '',
                 children: [],
+                createdAt: new Date().toISOString(),
+                closedAt: null,
             },
         ],
     },

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-priority-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-priority-demo.component.ts
@@ -12,6 +12,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.URGENT,
         parentTaskId: '',
         children: [],
+        createdAt: new Date().toISOString(),
+        closedAt: null,
     },
     {
         id: listId + 'task-two',
@@ -22,6 +24,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.HIGH,
         parentTaskId: '',
         children: [],
+        createdAt: new Date().toISOString(),
+        closedAt: null,
     },
     {
         id: listId + 'task-three',
@@ -32,6 +36,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.MEDIUM,
         parentTaskId: '',
         children: [],
+        createdAt: new Date().toISOString(),
+        closedAt: null,
     },
     {
         id: listId + 'task-four',
@@ -42,6 +48,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        createdAt: new Date().toISOString(),
+        closedAt: null,
     },
     {
         id: listId + 'task-five',
@@ -52,6 +60,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.OPTIONAL,
         parentTaskId: '',
         children: [],
+        createdAt: new Date().toISOString(),
+        closedAt: null,
     },
 ]
 

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-status-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-status-demo.component.ts
@@ -13,6 +13,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
     {
         id: listId + 'task-two',
@@ -23,6 +25,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
     {
         id: listId + 'task-three',
@@ -33,6 +37,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
     {
         id: listId + 'task-four',
@@ -43,6 +49,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
     {
         id: listId + 'task-five',
@@ -53,6 +61,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         priority: TaskPriority.NONE,
         parentTaskId: '',
         children: [],
+        closedAt: null,
+        createdAt: new Date().toISOString(),
     },
 ]
 

--- a/apps/rockket-web/src/app/store/entities/entities.selectors.ts
+++ b/apps/rockket-web/src/app/store/entities/entities.selectors.ts
@@ -1,18 +1,8 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store'
 import { EntitiesState } from './entities.state'
-import { applySorters, sortByPriority, sortByStatus } from './utils'
 
 export const entitiesFeature = createFeatureSelector<EntitiesState>('entities')
 
 export const entitiesSelectors = {
-    taskTreeMap: createSelector(entitiesFeature, ({ taskTreeMap }) => {
-        if (!taskTreeMap) return null
-        const sortedTreeMap = Object.fromEntries(
-            Object.entries(taskTreeMap).map(([listId, taskTree]) => {
-                return [listId, applySorters(taskTree, sortByPriority, sortByStatus)]
-            }),
-        )
-
-        return sortedTreeMap
-    }),
+    taskTreeMap: createSelector(entitiesFeature, ({ taskTreeMap }) => taskTreeMap),
 }

--- a/apps/rockket-web/src/app/store/entities/list/list.reducer.ts
+++ b/apps/rockket-web/src/app/store/entities/list/list.reducer.ts
@@ -16,22 +16,25 @@ export const tasklistReducerOns: ReducerOns<EntitiesState> = [
                 children: [],
             }
 
-            if (!parentListId)
+            if (!parentListId) {
                 return {
                     ...state,
-                    entityTree: [...(state.entityTree || []), listEntity],
+                    entityTree: [listEntity, ...(state.entityTree || [])],
                 }
+            }
 
             const entityTreeCopy = structuredClone(state.entityTree) || []
             const parentList = getEntityById(entityTreeCopy, parentListId)
 
-            if (!parentList)
+            if (!parentList) {
                 return {
                     ...state,
-                    entityTree: [...(state.entityTree || []), listEntity],
+                    entityTree: [listEntity, ...(state.entityTree || [])],
                 }
+            }
 
-            parentList.children?.push(listEntity)
+            parentList.children ??= []
+            parentList.children.unshift(listEntity)
 
             return {
                 ...state,

--- a/apps/rockket-web/src/app/store/entities/task/task.reducer.ts
+++ b/apps/rockket-web/src/app/store/entities/task/task.reducer.ts
@@ -29,12 +29,12 @@ export const taskReducerOns: ReducerOns<EntitiesState> = [
         if (!newTaskTreeMap[createdTask.listId]) newTaskTreeMap[createdTask.listId] = []
 
         const createdTaskRecursive: TaskPreviewRecursive = { ...createdTask, children: null }
-        if (!createdTask.parentTaskId) newTaskTreeMap[createdTask.listId].push(createdTaskRecursive)
+        if (!createdTask.parentTaskId) newTaskTreeMap[createdTask.listId].unshift(createdTaskRecursive)
         else {
             const parentTask = getTaskById(newTaskTreeMap[createdTask.listId], createdTask.parentTaskId)
             if (!parentTask) throw new Error('Could not find parent task')
 
-            if (parentTask.children) parentTask.children.push(createdTaskRecursive)
+            if (parentTask.children) parentTask.children.unshift(createdTaskRecursive)
             else parentTask.children = [createdTaskRecursive]
         }
 

--- a/apps/rockket-web/src/app/store/entities/utils.ts
+++ b/apps/rockket-web/src/app/store/entities/utils.ts
@@ -191,9 +191,23 @@ export const getTaskById = (taskTree: TaskPreviewRecursive[], id: string) => {
 
 export type TaskSorter = (a: TaskPreview, b: TaskPreview) => number
 
-export const sortByStatus: TaskSorter = (a, b) => statusSortingMap[a.status] - statusSortingMap[b.status]
-export const sortByPriority: TaskSorter = (a, b) =>
-    prioritySortingMap[a.priority] - prioritySortingMap[b.priority]
+export const sortTasks = {
+    byStatus: (a, b) => statusSortingMap[a.status] - statusSortingMap[b.status],
+
+    byPriority: (a, b) => prioritySortingMap[a.priority] - prioritySortingMap[b.priority],
+
+    byCreatedAtAsc: (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    byCreatedAtDesc: (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+
+    byClosedAtAsc: (a, b) => {
+        if (!a.closedAt || !b.closedAt) return 0
+        return new Date(a.closedAt).getTime() - new Date(b.closedAt).getTime()
+    },
+    byClosedAtDesc: (a, b) => {
+        if (!a.closedAt || !b.closedAt) return 0
+        return new Date(b.closedAt).getTime() - new Date(a.closedAt).getTime()
+    },
+} satisfies Record<string, TaskSorter>
 
 export const applySorters = (
     taskTree: TaskPreviewRecursive[],

--- a/packages/commons/src/list/list.model.ts
+++ b/packages/commons/src/list/list.model.ts
@@ -11,7 +11,7 @@ export type TaskList = {
     // Participants: string[] // maybe this one as well
 }
 
-export type TasklistPreview = Pick<TaskList, 'id' | 'title' | 'childLists' | 'parentListId'>
+export type TasklistPreview = Pick<TaskList, 'id' | 'title' | 'childLists' | 'parentListId' | 'createdAt'>
 
 export type TasklistDetail = Pick<TaskList, 'description' | 'ownerId' | 'createdAt'>
 

--- a/packages/commons/src/task/task.model.ts
+++ b/packages/commons/src/task/task.model.ts
@@ -42,7 +42,7 @@ export type Task = {
     openedAt: string
     deadline: string
     inProgressSince: string
-    closedAt: string
+    closedAt: string | null
 
     ownerId: string
     listId: string
@@ -52,7 +52,10 @@ export type Task = {
     subtaskIds: string[]
 }
 
-export type TaskPreview = Pick<Task, 'id' | 'title' | 'status' | 'priority' | 'listId' | 'parentTaskId'> & {
+export type TaskPreview = Pick<
+    Task,
+    'id' | 'title' | 'status' | 'priority' | 'listId' | 'parentTaskId' | 'closedAt' | 'createdAt'
+> & {
     description: string | null
 }
 export type TaskDetail = Task


### PR DESCRIPTION
### ️🪄 Changes <!-- List significant changes -->

- Updates queries on the BE to order by `createdAt`
- Removes sorting of tasks in the taskTreeMap store selector

<!-- Delete this comment if you need '💥 Breaking Changes'
#### 💥 Breaking Changes

-

<!-- (optional) -->

<!-- Delete this comment if you need '🚧 TODO'
### 🚧 TODO

- [ ]

<!-- (optional - recommended for draft PRs) -->

### 🧪 What/How to test this PR <!-- Briefly outline what and how to test changes in this PR -->

-

### ✅ Checklist <!-- Ensure all of these points are covered before marking the PR as ready for review: -->

- [ ] All linter warnings are resolved and code is formatted (`npm run fix`)
- [ ] Affected projects build and test successfully (`npm run affected`)
- [ ] Apps can be served (`npm run dev`)
- [ ] Package versions incremented according to [semantic versioning](https://semver.org/), `package-lock.json` updated (`npm i`)
- [ ] Changes to ENV variables are reflected in the respective `env.sample` files
- [ ] Breaking changes flagged

#### Misc

- [ ] Code is sufficiently documented with comments
- [ ] Docs updated to reflect changes
- [ ] All code used for temporary testing removed (`console.log()` etc.)
- [ ] Outstanding todos marked with `@TODO` comments
- [ ] All commented out code removed

#### Backend only <!-- Remove/ignore this section if the PR only contains frontend changes -->

- [ ] If the schema changed, migrations are generated and tested

#### Frontend only <!-- Remove/ignore this section if the PR only contains backend changes -->

- [ ] Tested on mobile device (`npm run dev:lan`)
