### PR TITLE
refactor: remove unnecessary `TaskPreview` type and `blockedByField` field

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,8 @@
                     "warn",
                     "always",
                     {
-                        "ignoreConsecutiveComments": true
+                        "ignoreConsecutiveComments": true,
+                        "ignorePattern": "prettier-ignore"
                     }
                 ]
             }

--- a/apps/rockket-backend/prisma/migrations/20240428142352_remove_blocked_by_relation/migration.sql
+++ b/apps/rockket-backend/prisma/migrations/20240428142352_remove_blocked_by_relation/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - The values [blockedById] on the enum `TaskEventUpdateField` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `blockedById` on the `Task` table. All the data in the column will be lost.
+
+*/
+
+-- Delete all TaskEvents that have the updatedField set to 'blockedById'
+DELETE FROM "TaskEvent" WHERE "updatedField" = 'blockedById';
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "TaskEventUpdateField_new" AS ENUM ('status', 'priority', 'deadline');
+ALTER TABLE "TaskEvent" ALTER COLUMN "updatedField" TYPE "TaskEventUpdateField_new" USING ("updatedField"::text::"TaskEventUpdateField_new");
+ALTER TYPE "TaskEventUpdateField" RENAME TO "TaskEventUpdateField_old";
+ALTER TYPE "TaskEventUpdateField_new" RENAME TO "TaskEventUpdateField";
+DROP TYPE "TaskEventUpdateField_old";
+COMMIT;
+
+
+-- DropForeignKey
+ALTER TABLE "Task" DROP CONSTRAINT "Task_blockedById_fkey";
+
+-- AlterTable
+ALTER TABLE "Task" DROP COLUMN "blockedById";

--- a/apps/rockket-backend/prisma/schema.prisma
+++ b/apps/rockket-backend/prisma/schema.prisma
@@ -101,29 +101,17 @@ model Task {
     //
     parentTask   Task?    @relation("task-parent-child", fields: [parentTaskId], references: [id])
     parentTaskId String?
-    //
-    blockedBy    Task?    @relation("blocking", fields: [blockedById], references: [id])
-    blockedById  String?
-    //   ||
-    //   ||
-    //  _||_
-    //  \  /
-    //   \/
-    // dependencies Task[] @relation("dependencies")
-    // dependendents Task[] @relation("dependencies")
+    subtasks     Task[]   @relation("task-parent-child")
 
-    subtasks     Task[]        @relation("task-parent-child")
-    tasksBlocked Task[]        @relation("blocking")
-    events       TaskEvent[]
-    comments     TaskComment[]
+    events   TaskEvent[]
+    comments TaskComment[]
 }
+
 
 enum TaskEventUpdateField {
     status
     priority
     deadline
-    blockedById
-    // ...and labels, once we introduce them
 }
 
 model TaskEvent {

--- a/apps/rockket-backend/prisma/schema.prisma
+++ b/apps/rockket-backend/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Task {
     parentTask   Task?    @relation("task-parent-child", fields: [parentTaskId], references: [id])
     parentTaskId String?
     subtasks     Task[]   @relation("task-parent-child")
-
+    //
     events   TaskEvent[]
     comments TaskComment[]
 }

--- a/apps/rockket-backend/prisma/schema.prisma
+++ b/apps/rockket-backend/prisma/schema.prisma
@@ -107,7 +107,6 @@ model Task {
     comments TaskComment[]
 }
 
-
 enum TaskEventUpdateField {
     status
     priority

--- a/apps/rockket-web/src/app/components/molecules/editable-entity-heading/editable-entity-title.component.ts
+++ b/apps/rockket-web/src/app/components/molecules/editable-entity-heading/editable-entity-title.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { Store } from '@ngrx/store'
-import { EntityPreviewRecursive, EntityType, TaskPreview } from '@rockket/commons'
+import { EntityPreviewRecursive, EntityType, Task } from '@rockket/commons'
 import { BehaviorSubject, distinctUntilKeyChanged, filter, first, map, of, switchMap } from 'rxjs'
 import { LoadingStateService } from 'src/app/services/loading-state.service'
 import { ENTITY_TITLE_DEFAULTS } from 'src/app/shared/defaults'
@@ -26,10 +26,10 @@ export class EditableEntityTitleComponent {
     ENTITY_TITLE_DEFAULTS = ENTITY_TITLE_DEFAULTS
 
     entity$ = new BehaviorSubject<
-        (EntityPreviewRecursive & Pick<TaskPreview, 'status' | 'priority'>) | undefined | null
+        (EntityPreviewRecursive & Pick<Task, 'status' | 'priority'>) | undefined | null
     >(null)
     @Input() set entity(activeEntity: EntityPreviewRecursive | undefined | null) {
-        this.entity$.next(activeEntity as EntityPreviewRecursive & Pick<TaskPreview, 'status' | 'priority'>)
+        this.entity$.next(activeEntity as EntityPreviewRecursive & Pick<Task, 'status' | 'priority'>)
     }
 
     titleUpdates$ = new BehaviorSubject<string | null>(null)

--- a/apps/rockket-web/src/app/components/molecules/page-progress-bar/page-progress-bar.component.css
+++ b/apps/rockket-web/src/app/components/molecules/page-progress-bar/page-progress-bar.component.css
@@ -3,7 +3,7 @@
     transition: box-shadow 100ms, width 800ms ease-in-out;
 }
 .progress {
-    transition: box-shadow 450ms, width 800ms ease-in-out;
+    transition: box-shadow 450ms, width 800ms ease-out;
 }
 .progress-container.glow span {
     @apply text-submit-400;

--- a/apps/rockket-web/src/app/components/molecules/page-progress-bar/page-progress-bar.component.ts
+++ b/apps/rockket-web/src/app/components/molecules/page-progress-bar/page-progress-bar.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
-import { TaskPreview, TaskPreviewRecursive, TaskStatus } from '@rockket/commons'
+import { Task, TaskRecursive, TaskStatus } from '@rockket/commons'
 import {
     BehaviorSubject,
     combineLatest,
@@ -18,7 +18,7 @@ import { TwColorClass, taskStatusColorMap } from 'src/app/shared/colors'
 import { EntityViewComponent } from '../../organisms/entity-view/entity-view.component'
 import { taskStatusLabelMap } from '../../atoms/icons/icon/icons'
 
-export const mapByStatus = <T extends TaskPreview>(taskTree: T[]) => {
+export const mapByStatus = <T extends Task>(taskTree: T[]) => {
     const statusCountMap = Object.values(TaskStatus).reduce(
         (acc, status) => ({
             ...acc,
@@ -29,7 +29,7 @@ export const mapByStatus = <T extends TaskPreview>(taskTree: T[]) => {
     return statusCountMap
 }
 
-export const getStatusCountMapRecursive = (taskTree: TaskPreviewRecursive[]): Record<TaskStatus, number> => {
+export const getStatusCountMapRecursive = (taskTree: TaskRecursive[]): Record<TaskStatus, number> => {
     const map = Object.fromEntries(
         Object.entries(mapByStatus(taskTree)).map(([status, tasks]) => [status, tasks.length]),
     ) as Record<TaskStatus, number>
@@ -72,8 +72,8 @@ export class PageProgressBarComponent {
         [TaskStatus.BACKLOG]: 'text-tinted-200',
     }
 
-    taskTree$ = new BehaviorSubject<TaskPreviewRecursive[]>([])
-    @Input() set taskTree(tasks: TaskPreviewRecursive[]) {
+    taskTree$ = new BehaviorSubject<TaskRecursive[]>([])
+    @Input() set taskTree(tasks: TaskRecursive[]) {
         this.taskTree$.next(tasks)
     }
 

--- a/apps/rockket-web/src/app/components/organisms/entity-view/entity-view.component.ts
+++ b/apps/rockket-web/src/app/components/organisms/entity-view/entity-view.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { Store } from '@ngrx/store'
-import { EntityPreviewRecursive, EntityType, TaskPreview } from '@rockket/commons'
+import { EntityPreviewRecursive, EntityType, Task } from '@rockket/commons'
 import {
     BehaviorSubject,
     Observable,
@@ -77,7 +77,7 @@ export class EntityViewComponent {
             if (!entity) return null
 
             return optionsMap?.[entity.entityType].map(
-                useTaskForActiveItems(entity as EntityPreviewRecursive & TaskPreview),
+                useTaskForActiveItems(entity as EntityPreviewRecursive & Task),
             )
         }),
         shareReplay({ bufferSize: 1, refCount: true }),

--- a/apps/rockket-web/src/app/components/organisms/entity-view/views/task-view/task-view.component.cy.ts
+++ b/apps/rockket-web/src/app/components/organisms/entity-view/views/task-view/task-view.component.cy.ts
@@ -57,24 +57,17 @@ const entityFixture: EntityPreviewRecursive = {
     title: 'The mock title',
     children: [],
     parentId: '',
-}
-const taskDetailFixture: TaskDetail = {
     description: '',
-    createdAt: '',
-    ownerId: '',
-    title: 'The mock title',
-    blockedById: '',
-    closedAt: '',
-    deadline: '',
-    id: 'the mock id',
-    inProgressSince: '',
+    createdAt: new Date(),
+    statusUpdatedAt: new Date(),
+    ownerId: '5',
+    deadline: null,
     listId: '',
-    openedAt: '',
     parentTaskId: '',
     priority: TaskPriority.MEDIUM,
     status: TaskStatus.OPEN,
-    subtaskIds: [],
 }
+const taskDetailFixture: TaskDetail = {}
 
 describe('TaskViewComponent', () => {
     it('renders the task', () => {

--- a/apps/rockket-web/src/app/components/organisms/entity-view/views/task-view/task-view.component.ts
+++ b/apps/rockket-web/src/app/components/organisms/entity-view/views/task-view/task-view.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Inject, ViewChild } from '@angular/core'
 import { UntilDestroy } from '@ngneat/until-destroy'
 import { Store } from '@ngrx/store'
-import { TaskDetail } from '@rockket/commons'
+import { EntityPreviewRecursive, EntityType, TaskDetail, TaskEntityPreview } from '@rockket/commons'
 import {
     Subject,
     combineLatest,
@@ -48,11 +48,12 @@ export class TaskViewComponent {
     detail$ = this.viewData.detail$
     options$ = this.viewData.options$
 
-    description$ = this.detail$.pipe(
-        map(detail => {
-            if (!detail) return null
-            return detail.description || ''
-        }),
+    description$ = this.taskEntity$.pipe(
+        filter(
+            (taskEntity): taskEntity is EntityPreviewRecursive & TaskEntityPreview =>
+                taskEntity?.entityType == EntityType.TASK,
+        ),
+        map(detail => detail.description || ''),
         distinctUntilChanged(),
     )
     descriptionContext$ = this.taskEntity$.pipe(

--- a/apps/rockket-web/src/app/components/organisms/task-tree/task-tree.component.cy.ts
+++ b/apps/rockket-web/src/app/components/organisms/task-tree/task-tree.component.cy.ts
@@ -1,5 +1,5 @@
 import { CdkMenuModule } from '@angular/cdk/menu'
-import { TaskPreviewRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 import { testName } from 'cypress/support/helpers'
 import { FocusableDirective } from 'src/app/directives/focusable.directive'
 import { MutationDirective } from 'src/app/directives/mutation.directive'
@@ -13,7 +13,7 @@ import { InlineEditorComponent } from '../../atoms/inline-editor/inline-editor.c
 import { TaskComponent } from '../task/task.component'
 import { TaskTreeComponent } from './task-tree.component'
 
-const setupComponent = (taskTree: TaskPreviewRecursive[]) => {
+const setupComponent = (taskTree: TaskRecursive[]) => {
     cy.mount(`<app-task-tree [tasks]="taskTree"></app-task-tree>`, {
         componentProperties: { taskTree },
         imports: [IconsModule, CdkMenuModule, RxModule, RichTextEditorModule, DropdownModule],
@@ -29,7 +29,7 @@ const setupComponent = (taskTree: TaskPreviewRecursive[]) => {
     })
 }
 
-const newTaskRecursive = (args?: { children: TaskPreviewRecursive[] }): TaskPreviewRecursive => ({
+const newTaskRecursive = (args?: { children: TaskRecursive[] }): TaskRecursive => ({
     id: Math.random().toString(),
     title: 'A Task title',
     listId: '1',
@@ -38,9 +38,13 @@ const newTaskRecursive = (args?: { children: TaskPreviewRecursive[] }): TaskPrev
     priority: TaskPriority.OPTIONAL,
     status: TaskStatus.BACKLOG,
     children: args?.children || [],
+    createdAt: new Date(),
+    deadline: null,
+    ownerId: '5',
+    statusUpdatedAt: new Date(),
 })
 
-const taskTreeFixture: TaskPreviewRecursive[] = [
+const taskTreeFixture: TaskRecursive[] = [
     newTaskRecursive({
         children: [newTaskRecursive(), newTaskRecursive()],
     }),

--- a/apps/rockket-web/src/app/components/organisms/task-tree/task-tree.component.ts
+++ b/apps/rockket-web/src/app/components/organisms/task-tree/task-tree.component.ts
@@ -2,8 +2,8 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { Store } from '@ngrx/store'
 import {
     EntityType,
-    TaskPreviewFlattend,
-    TaskPreviewRecursive,
+    TaskFlattend,
+    TaskRecursive,
     TaskPriority,
     TaskStatus,
     TaskStatusGroup,
@@ -21,14 +21,14 @@ import { applyMapperRecursive, flattenTaskTree, sortTasks } from 'src/app/store/
 import { useTaskForActiveItems } from 'src/app/utils/menu-item.helpers'
 
 export interface TaskTreeNode {
-    taskPreview: TaskPreviewFlattend
+    taskPreview: TaskFlattend
     hasChildren: boolean
     isExpanded: boolean
     isDescriptionExpanded: boolean
     path: string[]
 }
 
-export const convertToTaskTreeNode = (task: TaskPreviewFlattend, expand?: boolean): TaskTreeNode => {
+export const convertToTaskTreeNode = (task: TaskFlattend, expand?: boolean): TaskTreeNode => {
     return {
         taskPreview: task,
         hasChildren: (task.children?.length || 0) > 0,
@@ -51,8 +51,8 @@ export class TaskTreeComponent {
         private uiStateService: UiStateService,
     ) {}
 
-    tasks$ = new BehaviorSubject<TaskPreviewRecursive[] | null>(null)
-    @Input() set tasks(tasks: TaskPreviewRecursive[]) {
+    tasks$ = new BehaviorSubject<TaskRecursive[] | null>(null)
+    @Input() set tasks(tasks: TaskRecursive[]) {
         this.tasks$.next(tasks)
     }
     @Input() highlightQuery = ''

--- a/apps/rockket-web/src/app/components/organisms/task/task.component.cy.ts
+++ b/apps/rockket-web/src/app/components/organisms/task/task.component.cy.ts
@@ -1,6 +1,6 @@
 import { CdkMenuModule } from '@angular/cdk/menu'
 import { Store } from '@ngrx/store'
-import { EntityType, TaskPreviewFlattend, TaskPriority, TaskStatus } from '@rockket/commons'
+import { EntityType, TaskFlattend, TaskPriority, TaskStatus } from '@rockket/commons'
 import { testName, useStubsForActions } from 'cypress/support/helpers'
 import { FocusableDirective } from 'src/app/directives/focusable.directive'
 import { MutationDirective } from 'src/app/directives/mutation.directive'
@@ -53,7 +53,7 @@ const setupComponent = (
     )
 }
 
-const taskFixture: TaskPreviewFlattend = {
+const taskFixture: TaskFlattend = {
     title: 'The title',
     children: [],
     description: '',
@@ -63,6 +63,10 @@ const taskFixture: TaskPreviewFlattend = {
     path: [],
     priority: TaskPriority.NONE,
     status: TaskStatus.OPEN,
+    createdAt: new Date(),
+    ownerId: '5',
+    statusUpdatedAt: new Date(),
+    deadline: null,
 }
 const taskTreeNodeFixture: TaskTreeNode = {
     hasChildren: false,

--- a/apps/rockket-web/src/app/components/organisms/task/task.component.spec.ts
+++ b/apps/rockket-web/src/app/components/organisms/task/task.component.spec.ts
@@ -1,6 +1,6 @@
 import { CdkMenuModule } from '@angular/cdk/menu'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { TaskPreviewFlattend, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskFlattend, TaskPriority, TaskStatus } from '@rockket/commons'
 import { BehaviorSubject } from 'rxjs'
 import { FocusableDirective } from 'src/app/directives/focusable.directive'
 import { HighlightPipe } from 'src/app/pipes/highlight.pipe'
@@ -22,23 +22,21 @@ describe('TaskComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TaskComponent)
         component = fixture.componentInstance
-        component.task$ = new BehaviorSubject({
+        component.task$ = new BehaviorSubject<TaskFlattend | null>({
             id: '',
             title: 'Task title here',
             priority: TaskPriority.NONE,
             status: TaskStatus.OPEN,
             description: '',
             listId: '',
-            // OwnerId: '',
-            // closedAt: '',
-            // deadline: '',
-            // openedAt: '',
-            // createdAt: '',
-            // subtaskIds: [],
-            // blockedById: '',
+            ownerId: '5',
+            deadline: null,
+            createdAt: new Date(),
+            statusUpdatedAt: new Date(),
             parentTaskId: '',
-            // InProgressSince: '',
-        } as null | TaskPreviewFlattend)
+            children: [],
+            path: [],
+        })
         fixture.detectChanges()
     })
 

--- a/apps/rockket-web/src/app/components/organisms/task/task.component.ts
+++ b/apps/rockket-web/src/app/components/organisms/task/task.component.ts
@@ -9,14 +9,7 @@ import {
     ViewChild,
 } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
-import {
-    EntityType,
-    TaskPreview,
-    TaskPreviewFlattend,
-    TaskPreviewRecursive,
-    TaskPriority,
-    TaskStatus,
-} from '@rockket/commons'
+import { EntityType, Task, TaskFlattend, TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 import { createDocument, getSchema } from '@tiptap/core'
 import {
     BehaviorSubject,
@@ -110,7 +103,7 @@ export class TaskComponent {
         this.searchTerm$.next(value)
     }
 
-    task$ = new BehaviorSubject<TaskPreviewFlattend | null>(null)
+    task$ = new BehaviorSubject<TaskFlattend | null>(null)
     nodeData$ = new BehaviorSubject<Omit<TaskTreeNode, 'taskPreview'> | null>(null)
     @Input() set data({ taskPreview, ...data }: TaskTreeNode) {
         this.nodeData$.next(data)
@@ -165,7 +158,6 @@ export class TaskComponent {
     get loading() {
         return this.isLoading ? EntityState.LOADING : false
     }
-    blocked = false // Disabled for now
 
     @Input() readonly = false
 
@@ -279,7 +271,7 @@ export class TaskComponent {
         return this.counterWidget
     }
 
-    getTaskProgress(task: { children?: TaskPreview[] | null }): ChecklistCount {
+    getTaskProgress(task: { children?: Task[] | null }): ChecklistCount {
         const totalItems = task.children?.length || 0
         const checkedItems =
             task.children?.filter(
@@ -289,7 +281,7 @@ export class TaskComponent {
 
         return { totalItems, checkedItems, progress }
     }
-    getTaskProgressRecursive(task: { children?: TaskPreviewRecursive[] | null }): ChecklistCount {
+    getTaskProgressRecursive(task: { children?: TaskRecursive[] | null }): ChecklistCount {
         const statusTaskCountMap = getStatusCountMapRecursive(task.children || [])
 
         const totalItems = Object.values(statusTaskCountMap).reduce((acc, curr) => acc + curr)

--- a/apps/rockket-web/src/app/pages/component-playground/tasks-demo/tasks-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/component-playground/tasks-demo/tasks-demo.component.ts
@@ -2,8 +2,8 @@ import { Component } from '@angular/core'
 import {
     prioritySortingMap,
     statusSortingMap,
-    TaskPreview,
-    TaskPreviewFlattend,
+    Task,
+    TaskFlattend,
     TaskPriority,
     TaskStatus,
 } from '@rockket/commons'
@@ -12,14 +12,14 @@ import {
     TaskTreeNode,
 } from 'src/app/components/organisms/task-tree/task-tree.component'
 
-type TaskSorter = (a: TaskPreview, b: TaskPreview) => number
+type TaskSorter = (a: Task, b: Task) => number
 
 const sortByStatus: TaskSorter = (a, b) => statusSortingMap[a.status] - statusSortingMap[b.status]
 const sortByPriority: TaskSorter = (a, b) => prioritySortingMap[a.priority] - prioritySortingMap[b.priority]
 
 const tasklist = Object.values(TaskStatus)
     .map(status =>
-        Object.values(TaskPriority).map<TaskPreview>((priority, i) => ({
+        Object.values(TaskPriority).map<Task>((priority, i) => ({
             title: `This is a task (${status}, ${priority})`,
             description:
                 i % 2 == 0
@@ -32,11 +32,13 @@ const tasklist = Object.values(TaskStatus)
             parentTaskId: '',
             createdAt: new Date(),
             statusUpdatedAt: new Date(),
+            deadline: null,
+            ownerId: '5',
         })),
     )
     .flat()
 
-const sortTasklist = (tasklist: TaskPreview[]) => {
+const sortTasklist = (tasklist: Task[]) => {
     const openTasks = tasklist
         .filter(
             // Prettier-ignore
@@ -62,7 +64,7 @@ const sortTasklist = (tasklist: TaskPreview[]) => {
 })
 export class TasksDemoComponent {
     tasks: TaskTreeNode[] = sortTasklist(tasklist)
-        .map<TaskPreviewFlattend>(task => ({
+        .map<TaskFlattend>(task => ({
             ...task,
             path: [],
             children: [],

--- a/apps/rockket-web/src/app/pages/home/entity-page/entity-page.component.ts
+++ b/apps/rockket-web/src/app/pages/home/entity-page/entity-page.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core'
 import { ActivatedRoute } from '@angular/router'
 import { UntilDestroy } from '@ngneat/until-destroy'
 import { Store } from '@ngrx/store'
-import { EntityPreviewRecursive, EntityType, TaskPreview } from '@rockket/commons'
+import { EntityPreviewRecursive, EntityType, Task } from '@rockket/commons'
 import { combineLatestWith, map, of, shareReplay, switchMap } from 'rxjs'
 import { IconKey } from 'src/app/components/atoms/icons/icon/icons'
 import { Breadcrumb } from 'src/app/components/molecules/breadcrumbs/breadcrumbs.component'
@@ -70,20 +70,20 @@ export class EntityPageComponent {
         map(([trace, loadingMap]) =>
             trace?.map<Breadcrumb>(({ entityType, ...entity }) => {
                 const loadingIcon: false | IconKey = loadingMap[entity.id] && 'Loading'
-                const statusIcon = (entity as EntityPreviewRecursive & Pick<TaskPreview, 'status'>).status
+                const statusIcon = (entity as EntityPreviewRecursive & Pick<Task, 'status'>).status
 
                 let contextMenuItems: Breadcrumb['contextMenuItems']
 
                 if (entityType == EntityType.TASK) {
                     const taskEntity: TaskMenuItemData = {
-                        ...(entity as EntityPreviewRecursive & TaskPreview),
+                        ...(entity as EntityPreviewRecursive & Task),
                         entityType,
                     }
 
                     // @TODO: we must add the data for the tasks in the dropdown
                     contextMenuItems = this.entityOptionsMap[entityType].applyOperators(
                         useDataForAction(taskEntity),
-                        useTaskForActiveItems(taskEntity as EntityPreviewRecursive & TaskPreview),
+                        useTaskForActiveItems(taskEntity as EntityPreviewRecursive & Task),
                         useParamsForRoute({ id: entity.id }),
                     )
                 } else

--- a/apps/rockket-web/src/app/pages/home/home.component.ts
+++ b/apps/rockket-web/src/app/pages/home/home.component.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
 import { Store } from '@ngrx/store'
 import { Action } from '@ngrx/store/src/models'
-import { EntityPreviewFlattend, EntityType, TaskPreview } from '@rockket/commons'
+import { EntityPreviewFlattend, EntityType, Task } from '@rockket/commons'
 import { combineLatestWith, map, tap } from 'rxjs'
 import { MenuService } from 'src/app/components/templates/sidebar-layout/menu.service'
 import { MenuItem } from 'src/app/dropdown/drop-down/drop-down.component'
@@ -139,7 +139,7 @@ export class HomeComponent {
                         ...node,
                         isExpanded: this.entityExpandedMap.get(node.id) || isContainedInTrace,
                         menuItems: this.nodeMenuItemsMap[node.entityType].map(
-                            useTaskForActiveItems(node as EntityTreeNode & TaskPreview),
+                            useTaskForActiveItems(node as EntityTreeNode & Task),
                         ),
                     }
                 })

--- a/apps/rockket-web/src/app/pages/home/search/search.component.html
+++ b/apps/rockket-web/src/app/pages/home/search/search.component.html
@@ -56,11 +56,7 @@
                                     ></span>
                                 </div>
                                 <div
-                                    *rxIf="
-                                        getEntityDetail(entitiesState, entity.entityType, entity.id)
-                                            ?.description;
-                                        let desc
-                                    "
+                                    *rxIf="getEntityDescription(entitiesState, entity); let desc"
                                     class="description | bg-tinted-900 text-tinted-300 mt-1 h-full max-h-40 w-full overflow-y-auto rounded-lg px-2 py-1"
                                     [innerHTML]="desc | highlight : search.query"
                                 ></div>

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-description-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-description-demo.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { TaskPreviewRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 
 const listId = 'description-demo'
-const demoTasks: TaskPreviewRecursive[] = [
+const demoTasks: TaskRecursive[] = [
     {
         id: listId + 'task-one',
         title: 'Develop a social media campaign',
@@ -31,6 +31,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
 ]
 

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-nesting-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-nesting-demo.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { TaskPreviewRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 
 const listId = 'nesting-demo'
-const demoTasks: TaskPreviewRecursive[] = [
+const demoTasks: TaskRecursive[] = [
     {
         id: listId + 'task-one',
         title: 'Plan birthday party for sarah',
@@ -13,6 +13,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         parentTaskId: '',
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
         children: [
             {
                 id: listId + 'task-one-zero',
@@ -25,6 +27,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 children: [],
                 createdAt: new Date(),
                 statusUpdatedAt: new Date(),
+                ownerId: '5',
+                deadline: null,
             },
             {
                 id: listId + 'task-one-one',
@@ -36,6 +40,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 parentTaskId: '',
                 createdAt: new Date(),
                 statusUpdatedAt: new Date(),
+                ownerId: '5',
+                deadline: null,
                 children: [
                     {
                         id: listId + 'task-one-one-one',
@@ -48,6 +54,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                         children: [],
                         createdAt: new Date(),
                         statusUpdatedAt: new Date(),
+                        ownerId: '5',
+                        deadline: null,
                     },
                     {
                         id: listId + 'task-one-one-two',
@@ -60,6 +68,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                         children: [],
                         createdAt: new Date(),
                         statusUpdatedAt: new Date(),
+                        ownerId: '5',
+                        deadline: null,
                     },
                 ],
             },
@@ -82,6 +92,8 @@ const demoTasks: TaskPreviewRecursive[] = [
                 children: [],
                 createdAt: new Date(),
                 statusUpdatedAt: new Date(),
+                ownerId: '5',
+                deadline: null,
             },
         ],
     },

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-priority-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-priority-demo.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { TaskPreviewRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 
 const listId = 'priority-demo'
-const demoTasks: TaskPreviewRecursive[] = [
+const demoTasks: TaskRecursive[] = [
     {
         id: listId + 'task-one',
         title: 'Do that extremely urgent thing',
@@ -14,6 +14,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-two',
@@ -26,6 +28,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-three',
@@ -38,6 +42,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-four',
@@ -50,6 +56,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-five',
@@ -62,6 +70,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         createdAt: new Date(),
         statusUpdatedAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
 ]
 

--- a/apps/rockket-web/src/app/pages/landing-page/demos/task-status-demo.component.ts
+++ b/apps/rockket-web/src/app/pages/landing-page/demos/task-status-demo.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { TaskPreviewRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
+import { TaskRecursive, TaskPriority, TaskStatus } from '@rockket/commons'
 
 const listId = 'status-demo'
 
-const demoTasks: TaskPreviewRecursive[] = [
+const demoTasks: TaskRecursive[] = [
     {
         id: listId + 'task-one',
         title: 'This thing is currently in the making',
@@ -15,6 +15,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-two',
@@ -27,6 +29,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-three',
@@ -39,6 +43,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-four',
@@ -51,6 +57,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
     {
         id: listId + 'task-five',
@@ -63,6 +71,8 @@ const demoTasks: TaskPreviewRecursive[] = [
         children: [],
         statusUpdatedAt: new Date(),
         createdAt: new Date(),
+        ownerId: '5',
+        deadline: null,
     },
 ]
 

--- a/apps/rockket-web/src/app/services/entity.services/task.service.ts
+++ b/apps/rockket-web/src/app/services/entity.services/task.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
-import { CreateTaskDto, Task, UpdateTaskDto, fnContext, taskSchema } from '@rockket/commons'
-import { Observable } from 'rxjs'
+import { CreateTaskDto, Task, TaskDetail, UpdateTaskDto, fnContext, taskSchema } from '@rockket/commons'
+import { Observable, of } from 'rxjs'
 import { HttpService } from 'src/app/http/http.service'
 import { validateWith } from 'src/app/http/http.utils'
 import { HttpSuccessResponse } from 'src/app/http/types'
@@ -28,10 +28,10 @@ export class TaskService implements EntityService {
         return this.http.delete<HttpSuccessResponse>('/task/' + id)
     }
 
-    loadDetail(id: string): Observable<Task> {
-        return this.http
-            .get('/task/' + id)
-            .pipe(validateWith(taskSchema, fnContext(TaskService, this.loadDetail)))
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    loadDetail(id: string): Observable<TaskDetail> {
+        // Noop for now
+        return of({})
     }
 
     loadRootLevelTasks(listId: string): Observable<Task[]> {

--- a/apps/rockket-web/src/app/store/entities/entities.reducer.ts
+++ b/apps/rockket-web/src/app/store/entities/entities.reducer.ts
@@ -1,5 +1,5 @@
 import { createReducer, on } from '@ngrx/store'
-import { EntityPreviewRecursive, EntityType, Task, TaskList, TaskPreviewRecursive } from '@rockket/commons'
+import { EntityPreviewRecursive, EntityType, Task, TaskList, TaskRecursive } from '@rockket/commons'
 import { authActions } from '../user/user.actions'
 import { entitiesActions } from './entities.actions'
 import { EntitiesState, TaskTreeMap } from './entities.state'
@@ -116,7 +116,7 @@ export const entitiesReducer = createReducer(
                 // update task tree
                 if (entityType == EntityType.TASK) {
                     const task = entity as Task
-                    let containingArr: TaskPreviewRecursive[]
+                    let containingArr: TaskRecursive[]
 
                     if (!task.parentTaskId) {
                         taskTreeMapCopy[task.listId] ??= []

--- a/apps/rockket-web/src/app/store/entities/entities.state.ts
+++ b/apps/rockket-web/src/app/store/entities/entities.state.ts
@@ -2,11 +2,11 @@ import {
     EntityPreviewRecursive,
     EntityType,
     TaskDetail,
-    TaskPreviewRecursive,
+    TaskRecursive,
     TasklistDetail,
 } from '@rockket/commons'
 
-export type TaskTreeMap = Record<string, TaskPreviewRecursive[]>
+export type TaskTreeMap = Record<string, TaskRecursive[]>
 
 export interface EntitiesState {
     entityTree: EntityPreviewRecursive[] | null

--- a/apps/rockket-web/src/app/store/entities/task/task.actions.ts
+++ b/apps/rockket-web/src/app/store/entities/task/task.actions.ts
@@ -1,5 +1,5 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store'
-import { CreateTaskDto, TaskPreview, TaskPriority, TaskStatus } from '@rockket/commons'
+import { CreateTaskDto, Task, TaskPriority, TaskStatus } from '@rockket/commons'
 import { HttpServerErrorResponse, HttpServerErrorResponseWithMeta } from 'src/app/http/types'
 
 export const taskActions = createActionGroup({
@@ -7,15 +7,15 @@ export const taskActions = createActionGroup({
     events: {
         'load task previews': emptyProps(),
         'reload task previews': emptyProps(),
-        'load task previews success': props<{ previews: TaskPreview[] }>(),
+        'load task previews success': props<{ previews: Task[] }>(),
         'load task previews error': props<HttpServerErrorResponse>(),
 
         'load root level tasks': props<{ listId: string }>(),
-        'load root level tasks success': props<{ listId: string; tasks: TaskPreview[] }>(),
+        'load root level tasks success': props<{ listId: string; tasks: Task[] }>(),
         'load root level tasks error': props<HttpServerErrorResponseWithMeta>(),
 
         create: props<Partial<CreateTaskDto>>(),
-        'create success': props<{ createdTask: TaskPreview }>(),
+        'create success': props<{ createdTask: Task }>(),
         'create error': props<HttpServerErrorResponseWithMeta>(),
 
         'update status': props<{ id: string; status: TaskStatus }>(),

--- a/apps/rockket-web/src/app/store/entities/task/task.reducer.ts
+++ b/apps/rockket-web/src/app/store/entities/task/task.reducer.ts
@@ -1,5 +1,5 @@
 import { on } from '@ngrx/store'
-import { EntityType, TaskPreviewRecursive, getTaskStatusUpdatedAt } from '@rockket/commons'
+import { TaskRecursive, getTaskStatusUpdatedAt } from '@rockket/commons'
 import { ReducerOns } from 'src/app/utils/store.helpers'
 import { EntitiesState, TaskTreeMap } from '../entities.state'
 import { buildTaskTree, buildTaskTreeMap, getTaskById } from '../utils'
@@ -28,7 +28,7 @@ export const taskReducerOns: ReducerOns<EntitiesState> = [
         const newTaskTreeMap = structuredClone(state.taskTreeMap || {}) as TaskTreeMap
         if (!newTaskTreeMap[createdTask.listId]) newTaskTreeMap[createdTask.listId] = []
 
-        const createdTaskRecursive: TaskPreviewRecursive = { ...createdTask, children: null }
+        const createdTaskRecursive: TaskRecursive = { ...createdTask, children: null }
         if (!createdTask.parentTaskId) newTaskTreeMap[createdTask.listId].unshift(createdTaskRecursive)
         else {
             const parentTask = getTaskById(newTaskTreeMap[createdTask.listId], createdTask.parentTaskId)
@@ -77,7 +77,6 @@ export const taskReducerOns: ReducerOns<EntitiesState> = [
 
     on(taskActions.updateDescriptionSuccess, (state, { id, newDescription }) => {
         const taskTreeMapCopy = structuredClone(state.taskTreeMap || {}) as TaskTreeMap
-        const taskDetailsCopy = structuredClone(state.entityDetails[EntityType.TASK] || {})
 
         // @TODO: This could be optimized by using the `listId` to reduce the number of tasks to iterate over
         const task = getTaskById(Object.values(taskTreeMapCopy).flat(), id)
@@ -85,15 +84,9 @@ export const taskReducerOns: ReducerOns<EntitiesState> = [
             task.description = newDescription
         }
 
-        if (taskDetailsCopy[id]) taskDetailsCopy[id].description = newDescription
-
         return {
             ...state,
             taskTreeMap: taskTreeMapCopy,
-            entityDetails: {
-                ...state.entityDetails,
-                [EntityType.TASK]: taskDetailsCopy,
-            },
         }
     }),
 ]

--- a/apps/rockket-web/src/app/utils/menu-item.helpers.ts
+++ b/apps/rockket-web/src/app/utils/menu-item.helpers.ts
@@ -1,4 +1,4 @@
-import { TaskPreview } from '@rockket/commons'
+import { Task } from '@rockket/commons'
 import { interpolateParams } from '.'
 import { MenuItem } from '../dropdown/drop-down/drop-down.component'
 
@@ -81,7 +81,7 @@ export const useParamsForRoute = <T>(params: Record<string, string | number>) =>
 }
 
 /** Used to take a tasks status and set the respective status-item as `isActive` */
-export const useTaskForActiveStatus = (task: Pick<TaskPreview, 'status'>) => {
+export const useTaskForActiveStatus = (task: Pick<Task, 'status'>) => {
     return (taskStatusItem: MenuItem): MenuItem => ({
         ...taskStatusItem,
         // @TODO: this will break once the icon is not equl to the status anymore
@@ -89,7 +89,7 @@ export const useTaskForActiveStatus = (task: Pick<TaskPreview, 'status'>) => {
     })
 }
 /** Used to take a tasks priority and set the respective priority-item as `isActive` */
-export const useTaskForActivePriority = (task: Pick<TaskPreview, 'priority'>) => {
+export const useTaskForActivePriority = (task: Pick<Task, 'priority'>) => {
     return (taskPriorityItem: MenuItem): MenuItem => ({
         ...taskPriorityItem,
         // @TODO: this will break once the icon is not equl to the status anymore
@@ -97,7 +97,7 @@ export const useTaskForActivePriority = (task: Pick<TaskPreview, 'priority'>) =>
     })
 }
 /** Used to take a tasks status and priority and set the respective status/priority-items as `isActive` */
-export const useTaskForActiveItems = (task: Pick<TaskPreview, 'status' | 'priority'>) => {
+export const useTaskForActiveItems = (task: Pick<Task, 'status' | 'priority'>) => {
     return (item: MenuItem): MenuItem => {
         // Define mappers for the children of specific items
         const machine = {

--- a/packages/commons/src/entities.model.ts
+++ b/packages/commons/src/entities.model.ts
@@ -8,12 +8,18 @@ export enum EntityType {
     // VIEW = 'View',
 }
 
-export type EntityPreview = {
+type BaseEntityPreview = {
     id: string
     entityType: EntityType
     title: string
     parentId: string | undefined
 }
+
+export type TaskEntityPreview = BaseEntityPreview & { entityType: EntityType.TASK } & Task
+export type TasklistEntityPreview = BaseEntityPreview & { entityType: EntityType.TASKLIST }
+
+export type EntityPreview = TaskEntityPreview | TasklistEntityPreview
+
 export type EntityPreviewRecursive = EntityPreview & {
     children: EntityPreviewRecursive[] | undefined
 }

--- a/packages/commons/src/task/task.model.ts
+++ b/packages/commons/src/task/task.model.ts
@@ -40,29 +40,16 @@ export const taskSchema = z.object({
     statusUpdatedAt: z.date({ coerce: true }),
 
     deadline: z.date({ coerce: true }).nullable(),
-    blockedById: z.string().nullable(),
 })
 
 export type Task = z.infer<typeof taskSchema>
 
-// @TODO: Remove this, everything can just be the complete task
-export const taskPreviewSchema = taskSchema.pick({
-    id: true,
-    title: true,
-    status: true,
-    priority: true,
-    listId: true,
-    parentTaskId: true,
-    createdAt: true,
-    statusUpdatedAt: true,
-    description: true,
-})
+export const taskDetailSchema = z.object({})
+// @TODO: TaskDetail should (instead of just duplicating the task again) contain relationsTo, relationsFrom, comments, events
+export type TaskDetail = z.infer<typeof taskDetailSchema>
 
-export type TaskPreview = z.infer<typeof taskPreviewSchema>
-export type TaskDetail = Task
-
-export type TaskPreviewRecursive = TaskPreview & { children: TaskPreviewRecursive[] | null }
-export type TaskPreviewFlattend = TaskPreviewRecursive & { path: string[] }
+export type TaskRecursive = Task & { children: TaskRecursive[] | null }
+export type TaskFlattend = TaskRecursive & { path: string[] }
 
 export const statusSortingMap: Record<TaskStatus, number> = {
     [TaskStatus.IN_PROGRESS]: 0,


### PR DESCRIPTION
### ️🪄 Changes <!-- List significant changes -->

- Remove unnecessary type `TaskPreview` which already included more than half of the full data
- Remove task field `blockedBy` in favour of a future `relations` feature and because it was never used anyway
- Type `TaskDetail` is a noop for now, since we already have all the data in the `taskTreeMap`. In the future it will contain `relations`, `events`, `comments`

<!-- (optional) -->

<!-- Delete this comment if you need '🚧 TODO'
### 🚧 TODO

- [ ]

<!-- (optional - recommended for draft PRs) -->

### 🧪 What/How to test this PR <!-- Briefly outline what and how to test changes in this PR -->

-

### ✅ Checklist <!-- Ensure all of these points are covered before marking the PR as ready for review: -->

- [ ] All linter warnings are resolved and code is formatted (`npm run fix`)
- [ ] Affected projects build and test successfully (`npm run affected`)
- [ ] Apps can be served (`npm run dev`)
- [ ] Package versions incremented according to [semantic versioning](https://semver.org/), `package-lock.json` updated (`npm i`)
- [ ] Changes to ENV variables are reflected in the respective `env.sample` files
- [ ] Breaking changes flagged

#### Misc

- [ ] Code is sufficiently documented with comments
- [ ] Docs updated to reflect changes
- [ ] All code used for temporary testing removed (`console.log()` etc.)
- [ ] Outstanding todos marked with `@TODO` comments
- [ ] All commented out code removed

#### Backend only <!-- Remove/ignore this section if the PR only contains frontend changes -->

- [x] If the schema changed, migrations are generated and tested

#### Frontend only <!-- Remove/ignore this section if the PR only contains backend changes -->

- [ ] Tested on mobile device (`npm run dev:lan`)
