### PR TITLE
feat: implement abstraction for resizing panels

### DIFF
--- a/apps/rockket-web/src/app/app.module.ts
+++ b/apps/rockket-web/src/app/app.module.ts
@@ -66,6 +66,7 @@ import { SettingsGeneralComponent } from './pages/settings/general/general.compo
 import { SettingsComponent } from './pages/settings/settings.component'
 import { TermsOfServiceComponent } from './pages/terms-of-service/terms-of-service.component'
 import { HighlightPipe } from './pipes/highlight.pipe'
+import { ResizeModule } from './resize/resize.module'
 import { RichTextEditorModule } from './rich-text-editor/rich-text-editor.module'
 import { RxModule } from './rx/rx.module'
 import { effects, metaReducers, reducers } from './store'
@@ -143,6 +144,7 @@ import { TooltipModule } from './tooltip/tooltip.module'
         DropdownModule,
         KeyboardModule,
         RichTextEditorModule,
+        ResizeModule,
     ],
     providers: [
         {

--- a/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.cy.ts
+++ b/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.cy.ts
@@ -9,12 +9,14 @@ import { UserMenuComponent } from '../../organisms/user-menu/user-menu.component
 import { MainPaneComponent } from '../main-pane/main-pane.component'
 import { MenuToggleComponent } from './menu-toggle/menu-toggle.component'
 import { SidebarLayoutComponent } from './sidebar-layout.component'
+import { RxModule } from 'src/app/rx/rx.module'
+import { ResizeModule } from '../../../resize/resize.module'
 
 const setupComponent = (template: string) => {
     cy.mount(template, {
         componentProperties: {},
         providers: [storeMock, UiStateService, actionsMock],
-        imports: [OverlayModule, CdkMenuModule],
+        imports: [OverlayModule, CdkMenuModule, RxModule, ResizeModule],
         declarations: [
             SidebarLayoutComponent,
             UserMenuComponent,

--- a/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.cy.ts
+++ b/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.cy.ts
@@ -84,14 +84,14 @@ describe('SidebarLayoutComponent', () => {
             cy.viewport('macbook-13')
             setupComponent(defaultTemplate)
 
-            cy.get(testName('resize-handle'))
+            cy.get(testName('sidebar-resize-handle'))
                 .trigger('mousedown')
                 .trigger('mousemove', { clientX: 350, force: true })
                 .trigger('mouseup')
 
             cy.get(testName('sidebar')).then(e => expect(e.width()).greaterThan(348))
 
-            cy.get(testName('resize-handle'))
+            cy.get(testName('sidebar-resize-handle'))
                 .trigger('mousedown')
                 .trigger('mousemove', { clientX: 170, force: true })
                 .trigger('mouseup')
@@ -105,7 +105,7 @@ describe('SidebarLayoutComponent', () => {
                 `<app-sidebar-layout [enableResize]="false"> ${defaultContent} </app-sidebar-layout>`,
             )
 
-            cy.get(testName('resize-handle')).should('not.exist')
+            cy.get(testName('sidebar-resize-handle')).should('not.exist')
         })
     })
 })

--- a/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
+++ b/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
@@ -18,6 +18,7 @@
                 side="right"
                 (resizing)="onResize($event)"
                 (resizeEnd)="onResizeEnd($event)"
+                data-test-name="sidebar-resize-handle"
             ></app-resize-handle>
 
             <header

--- a/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
+++ b/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
@@ -18,7 +18,7 @@
                 side="right"
                 (resizing)="onResize($event)"
                 (resizeEnd)="onResizeEnd($event)"
-                data-test-name="sidebar-resize-handle"
+                testName="sidebar-resize-handle"
             ></app-resize-handle>
 
             <header

--- a/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
+++ b/apps/rockket-web/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
@@ -6,26 +6,20 @@
     <div class="relative flex h-[calc(100%-var(--bottom-nav-height))] md:h-full">
         <aside
             #sidebar
-            class="sidebar | sidebar--mobile | border-tinted-700 bg-tinted-800 md:text-md relative flex h-full shrink-0 flex-col md:w-[var(--sidebar-width,14rem)] md:min-w-[10rem] md:max-w-[70vw] md:border-r"
+            class="sidebar | sidebar--mobile | border-tinted-700 bg-tinted-850 md:text-md relative flex h-full shrink-0 flex-col md:w-[var(--sidebar-width,14rem)] md:min-w-[10rem] md:max-w-[60vw] md:border-r"
             [class.hide]="!(isMenuOpen$ | async)"
             [hidden]="!(isMenuOpen$ | async)"
             data-test-name="sidebar"
             [style.--sidebar-width]="uiState.width"
         >
-            <div
+            <app-resize-handle
                 *ngIf="enableResize"
-                #resizeHandle
-                class="resize-handle | group absolute -right-1 z-[1000] h-full w-2 cursor-col-resize"
-                data-test-name="resize-handle"
-                [appTooltip]="resizeHandleTooltip"
-            >
-                <ng-template #resizeHandleTooltip>
-                    Drag <span class="text-tinted-300">to resize the sidebar</span>
-                </ng-template>
-                <div
-                    class="group-hover:bg-tinted-400 relative left-[50%] h-full w-0.5 translate-x-[-50%] transition-colors delay-75"
-                ></div>
-            </div>
+                [resizeElement]="sidebar"
+                side="right"
+                (resizing)="onResize($event)"
+                (resizeEnd)="onResizeEnd($event)"
+            ></app-resize-handle>
+
             <header
                 class="sidebar-header | border-b border-transparent transition-colors"
                 [class.!border-tinted-700]="isSidebarScrolled"

--- a/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
+++ b/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ResizeHandleComponent } from './resize-handle.component'
+import { ResizeDirective } from './resize.directive'
 
 describe('ResizeComponent', () => {
     let component: ResizeHandleComponent
@@ -7,7 +8,7 @@ describe('ResizeComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [ResizeHandleComponent],
+            declarations: [ResizeHandleComponent, ResizeDirective],
         }).compileComponents()
 
         fixture = TestBed.createComponent(ResizeHandleComponent)

--- a/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
+++ b/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ResizeHandleComponent } from './resize-handle.component'
 import { ResizeDirective } from './resize.directive'
 
-describe('ResizeComponent', () => {
+describe(ResizeHandleComponent.name, () => {
     let component: ResizeHandleComponent
     let fixture: ComponentFixture<ResizeHandleComponent>
 

--- a/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
+++ b/apps/rockket-web/src/app/resize/resize-handle.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { ResizeHandleComponent } from './resize-handle.component'
+
+describe('ResizeComponent', () => {
+    let component: ResizeHandleComponent
+    let fixture: ComponentFixture<ResizeHandleComponent>
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ResizeHandleComponent],
+        }).compileComponents()
+
+        fixture = TestBed.createComponent(ResizeHandleComponent)
+        component = fixture.componentInstance
+        fixture.detectChanges()
+    })
+
+    it('should create', () => {
+        expect(component).toBeTruthy()
+    })
+})

--- a/apps/rockket-web/src/app/resize/resize-handle.component.ts
+++ b/apps/rockket-web/src/app/resize/resize-handle.component.ts
@@ -15,7 +15,7 @@ import { ResizeStrategy } from './resize.directive'
             #resize="appResize"
             (resizing)="resizing.emit($event)"
             (resizeEnd)="resizeEnd.emit($event)"
-            data-test-name="resize-handle"
+            [attr.data-test-name]="testName"
         >
             <div
                 class="group-hover:bg-tinted-400 group-[.isResizing]:bg-tinted-400 relative left-[50%] h-full w-0.5 translate-x-[-50%] transition-colors delay-75"
@@ -29,6 +29,7 @@ export class ResizeHandleComponent {
     @Input({ required: true }) resizeElement!: HTMLElement
     @Input() minSize?: number
     @Input() maxSize?: number
+    @Input() testName = 'resize-handle'
 
     @Output() resizing = new EventEmitter<number>()
     @Output() resizeEnd = new EventEmitter<number>()

--- a/apps/rockket-web/src/app/resize/resize-handle.component.ts
+++ b/apps/rockket-web/src/app/resize/resize-handle.component.ts
@@ -1,0 +1,35 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core'
+import { ResizeStrategy } from './resize.directive'
+
+@Component({
+    selector: 'app-resize-handle',
+    template: `
+        <div
+            class="handle-hitbox | group absolute z-[1000] h-full w-4 cursor-col-resize"
+            [class.-left-2]="side == 'left'"
+            [class.-right-2]="side == 'right'"
+            [appResize]="resizeElement"
+            [resizeStrategy]="side"
+            [minSize]="minSize"
+            [maxSize]="maxSize"
+            #resize="appResize"
+            (resizing)="resizing.emit($event)"
+            (resizeEnd)="resizeEnd.emit($event)"
+            data-test-name="resize-handle"
+        >
+            <div
+                class="group-hover:bg-tinted-400 group-[.isResizing]:bg-tinted-400 relative left-[50%] h-full w-0.5 translate-x-[-50%] transition-colors delay-75"
+            ></div>
+        </div>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ResizeHandleComponent {
+    @Input({ required: true }) side!: ResizeStrategy
+    @Input({ required: true }) resizeElement!: HTMLElement
+    @Input() minSize?: number
+    @Input() maxSize?: number
+
+    @Output() resizing = new EventEmitter<number>()
+    @Output() resizeEnd = new EventEmitter<number>()
+}

--- a/apps/rockket-web/src/app/resize/resize.directive.spec.ts
+++ b/apps/rockket-web/src/app/resize/resize.directive.spec.ts
@@ -2,7 +2,7 @@ import { ResizeDirective } from './resize.directive'
 
 describe('ResizeDirective', () => {
     it('should create an instance', () => {
-        const directive = new ResizeDirective({ nativeElement: new HTMLDivElement() })
+        const directive = new ResizeDirective({ nativeElement: document.createElement('div') })
         expect(directive).toBeTruthy()
     })
 })

--- a/apps/rockket-web/src/app/resize/resize.directive.spec.ts
+++ b/apps/rockket-web/src/app/resize/resize.directive.spec.ts
@@ -1,0 +1,8 @@
+import { ResizeDirective } from './resize.directive'
+
+describe('ResizeDirective', () => {
+    it('should create an instance', () => {
+        const directive = new ResizeDirective({ nativeElement: new HTMLDivElement() })
+        expect(directive).toBeTruthy()
+    })
+})

--- a/apps/rockket-web/src/app/resize/resize.directive.ts
+++ b/apps/rockket-web/src/app/resize/resize.directive.ts
@@ -1,0 +1,129 @@
+import { Directive, ElementRef, EventEmitter, Input, Output } from '@angular/core'
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
+import { coalesceWith } from '@rx-angular/cdk/coalescing'
+import {
+    Subject,
+    animationFrames,
+    debounceTime,
+    distinctUntilChanged,
+    filter,
+    fromEvent,
+    map,
+    merge,
+    startWith,
+    switchMap,
+    takeUntil,
+    tap,
+} from 'rxjs'
+import { isNotNullish } from '../utils'
+
+export type ResizeStrategy = 'left' | 'right'
+export type ResizerFn = (
+    event: MouseEvent,
+    offset: { offsetX: number; offsetY: number },
+    elem: HTMLElement,
+    minMax: { minSize: number; maxSize: number },
+) => number
+
+const resizeStrategyMap: Record<ResizeStrategy, ResizerFn> = {
+    left: (event: MouseEvent, { offsetX }, elem: HTMLElement, { minSize, maxSize }) => {
+        const rect = elem.getBoundingClientRect()
+        const rectLeftX = rect.x
+        const diff = rectLeftX - event.clientX + offsetX
+        const newWidth = rect.width + diff
+        const clampedWidth = Math.min(Math.max(newWidth, minSize), maxSize)
+
+        elem.style.width = clampedWidth + 'px'
+        return clampedWidth
+    },
+    right: (event: MouseEvent, { offsetX }, elem: HTMLElement, { minSize, maxSize }) => {
+        const rect = elem.getBoundingClientRect()
+        const rectRightX = rect.x + rect.width
+        const diff = event.clientX - rectRightX - offsetX
+        const newWidth = rect.width + diff
+        const clampedWidth = Math.min(Math.max(newWidth, minSize), maxSize)
+
+        elem.style.width = clampedWidth + 'px'
+        return clampedWidth
+    },
+}
+
+@UntilDestroy()
+@Directive({
+    selector: '[appResize]',
+    exportAs: 'appResize',
+    host: {
+        class: 'resize-handle',
+        '(mousedown)': 'mouseDown$.next($event)',
+    },
+})
+export class ResizeDirective {
+    constructor(private resizeHandleRef: ElementRef<HTMLElement>) {}
+
+    @Input({ alias: 'appResize', required: true }) resizeElem?: HTMLElement
+    @Input() resizeStrategy: ResizeStrategy = 'left'
+    @Input() customResizer?: ResizerFn
+    @Input() minSize?: number
+    @Input() maxSize?: number
+
+    @Output() resizing = new EventEmitter<number>()
+    @Output() resizeEnd = new EventEmitter<number>()
+
+    mouseDown$ = new Subject<MouseEvent>()
+
+    isResizing$ = merge(
+        this.mouseDown$.pipe(map(() => true)),
+        this.mouseDown$.pipe(
+            switchMap(() => fromEvent(document, 'mouseup', { once: true }).pipe(map(() => false))),
+        ),
+    ).pipe(startWith(false))
+
+    isResizingSubscription = this.isResizing$.pipe(untilDestroyed(this)).subscribe(isResizing => {
+        // @TODO: force the cursor to be the resize one (col-resize or row-resize, depending on the strategy)
+        if (isResizing) {
+            this.resizeHandleRef.nativeElement.classList.add('isResizing')
+            this.resizeElem?.classList.add('isResizing')
+        } else {
+            this.resizeHandleRef.nativeElement.classList.remove('isResizing')
+            this.resizeElem?.classList.remove('isResizing')
+        }
+    })
+
+    resize$ = this.mouseDown$.pipe(
+        switchMap(mouseDownEvent => {
+            const resizeHandleRect = this.resizeHandleRef.nativeElement.getBoundingClientRect()
+            const offset = {
+                /** Offset between the mouse x and the resize handle center */
+                offsetX: mouseDownEvent.clientX - resizeHandleRect.x - resizeHandleRect.width / 2,
+                /** Offset between the mouse y and the resize handle center */
+                offsetY: mouseDownEvent.clientY - resizeHandleRect.y - resizeHandleRect.height / 2,
+            }
+
+            return fromEvent<MouseEvent>(document, 'mousemove').pipe(
+                coalesceWith(animationFrames()),
+                takeUntil(fromEvent(document, 'mouseup', { once: true })),
+                map(mouseMoveEvent => [mouseMoveEvent, offset] as const),
+            )
+        }),
+        map(([event, offset]) => {
+            if (!this.resizeElem) return null
+
+            const calcAndApplyNewSize = this.customResizer || resizeStrategyMap[this.resizeStrategy]
+            const newSize = calcAndApplyNewSize(event, offset, this.resizeElem, {
+                minSize: this.minSize || 0,
+                maxSize: this.maxSize || Infinity,
+            })
+
+            return newSize
+        }),
+        filter(isNotNullish),
+        distinctUntilChanged(),
+        tap(size => this.resizing.emit(size)),
+    )
+    resizeEnd$ = this.resize$.pipe(
+        debounceTime(600),
+        tap(size => this.resizeEnd.emit(size)),
+    )
+
+    resizeSubscription = this.resizeEnd$.pipe(untilDestroyed(this)).subscribe()
+}

--- a/apps/rockket-web/src/app/resize/resize.module.ts
+++ b/apps/rockket-web/src/app/resize/resize.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { ResizeHandleComponent } from './resize-handle.component'
+import { ResizeDirective } from './resize.directive'
+
+@NgModule({
+    declarations: [ResizeDirective, ResizeHandleComponent],
+    imports: [CommonModule],
+    exports: [ResizeDirective, ResizeHandleComponent],
+})
+export class ResizeModule {}


### PR DESCRIPTION
### ️🪄 Changes <!-- List significant changes -->

- Implement abstraction for resizing panels
- Limit sidebar width to `60vw` (was `70vw` before)

<!-- Delete this comment if you need '💥 Breaking Changes'
#### 💥 Breaking Changes

-

<!---->

<!-- Delete this comment if you need '🚧 TODO'
### 🚧 TODO

- [ ]

<!---->

### 🧪 What/How to test this PR <!-- Briefly outline what and how to test changes in this PR -->

-

### 📋 Checklist <!-- Ensure all of these points are covered before marking the PR as ready for review: -->

- [ ] All linter warnings are resolved and code is formatted (`npm run fix`)
- [ ] Affected projects build and test successfully (`npm run affected`)
- [ ] Apps can be served (`npm run dev`)
- [ ] Changes to ENV variables are reflected in the respective `env.sample` files
- [ ] Breaking changes flagged
- [ ] `BE` If the schema changed, migrations are generated and tested
- [ ] `FE` Tested on mobile device (`npm run dev:lan`)
- [ ] `Misc` Code is sufficiently documented with comments
- [ ] `Misc` Docs updated to reflect changes
- [ ] `Misc` All code used for temporary testing removed (`console.log()` etc.)
- [ ] `Misc` Outstanding todos marked with `@TODO` comments
- [ ] `Misc` All commented out code removed``
